### PR TITLE
Consume central SSO from the admin identity provider

### DIFF
--- a/ng-src/app/admin/admin.models.ts
+++ b/ng-src/app/admin/admin.models.ts
@@ -19,6 +19,16 @@ export interface AuthTokens {
   user: UserProfile;
 }
 
+/**
+ * Session returned by the central IdP's /sso/session. No refresh token here — it lives only in
+ * the HttpOnly SSO cookie.
+ */
+export interface SsoSession {
+  accessToken: string;
+  accessTokenExpiresAt: string;
+  user: UserProfile;
+}
+
 export interface LoginResponse {
   twoFactorRequired: boolean;
   twoFactorToken?: string;

--- a/ng-src/app/admin/api.config.ts
+++ b/ng-src/app/admin/api.config.ts
@@ -1,12 +1,33 @@
 import { InjectionToken } from '@angular/core';
 
 /**
- * Base URL of the Blog Admin API. Overridable at deploy time by setting
- * `window.__ADMIN_API_BASE__` before the app boots (e.g. in index.html), so the
- * same static build can target different backends without a rebuild.
+ * Base URL of the Blog Admin RESOURCE API (content, media, links, users, settings).
+ * Overridable at deploy time via `window.__ADMIN_API_BASE__` before the app boots.
  */
 export const API_BASE = new InjectionToken<string>('API_BASE', {
   providedIn: 'root',
   factory: () =>
     (globalThis as any).__ADMIN_API_BASE__ ?? 'http://localhost:5080/api',
+});
+
+/**
+ * Base URL of the central IDENTITY PROVIDER API (admin.keshavsingh.in). Sessions, token refresh
+ * and account self-service are served from here — this app no longer authenticates users itself.
+ * Overridable via `window.__IDP_API_BASE__`. Must be a keshavsingh.in subdomain so the shared SSO
+ * cookie is sent (see the admin repo README).
+ */
+export const IDP_BASE = new InjectionToken<string>('IDP_BASE', {
+  providedIn: 'root',
+  factory: () =>
+    (globalThis as any).__IDP_API_BASE__ ?? 'http://localhost:5000/api',
+});
+
+/**
+ * Origin of the identity-provider SPA, used to redirect the browser for interactive sign-in.
+ * Overridable via `window.__ADMIN_APP_URL__`.
+ */
+export const ADMIN_APP_URL = new InjectionToken<string>('ADMIN_APP_URL', {
+  providedIn: 'root',
+  factory: () =>
+    (globalThis as any).__ADMIN_APP_URL__ ?? 'http://localhost:4200',
 });

--- a/ng-src/app/admin/guards/auth.guard.ts
+++ b/ng-src/app/admin/guards/auth.guard.ts
@@ -4,19 +4,22 @@ import { catchError, map, of } from 'rxjs';
 import { AuthService } from '../services/auth.service';
 import { Role } from '../admin.models';
 
-/** Blocks a route unless a session is active; tries a silent refresh first. */
+/**
+ * Blocks a route unless a session is active; tries a silent SSO exchange of the shared cookie
+ * first, so a user already signed in at the identity provider lands here without a second login.
+ * Failure redirects the browser to the central IdP sign-in.
+ */
 export const authGuard: CanActivateFn = () => {
   const auth = inject(AuthService);
-  const router = inject(Router);
 
   if (auth.isAuthenticated()) return of(true);
-  if (!auth.hasStoredSession()) return of(router.createUrlTree(['/admin/login']));
 
   return auth.refresh().pipe(
     map(() => true),
     catchError(() => {
       auth.forceClear();
-      return of(router.createUrlTree(['/admin/login']));
+      auth.loginRedirect();
+      return of(false);
     })
   );
 };
@@ -29,16 +32,15 @@ export const roleGuard = (...roles: Role[]): CanActivateFn => () => {
 };
 
 /**
- * Onboarding gate for normal pages: a user with a temporary password must change
- * it first, and a user without 2FA must enrol before doing anything else. The
- * change-password and security pages are intentionally left ungated so they are
- * reachable as the redirect targets.
+ * Onboarding gate: a user with a temporary password must change it first, and a user without 2FA
+ * must enrol before doing anything else. These flows are proxied to the central IdP. The
+ * change-password and security pages are intentionally left ungated as the redirect targets.
  */
 export const onboardingGuard: CanActivateFn = () => {
   const auth = inject(AuthService);
   const router = inject(Router);
   const user = auth.user();
-  if (!user) return router.createUrlTree(['/admin/login']);
+  if (!user) { auth.loginRedirect(); return false; }
   if (user.mustChangePassword) return router.createUrlTree(['/admin/account/password']);
   if (!user.twoFactorEnabled) return router.createUrlTree(['/admin/security']);
   return true;

--- a/ng-src/app/admin/interceptors/auth.interceptor.ts
+++ b/ng-src/app/admin/interceptors/auth.interceptor.ts
@@ -1,24 +1,22 @@
 import { HttpErrorResponse, HttpInterceptorFn } from '@angular/common/http';
 import { inject } from '@angular/core';
-import { Router } from '@angular/router';
 import { catchError, switchMap, throwError } from 'rxjs';
 import { AuthService } from '../services/auth.service';
-import { API_BASE } from '../api.config';
+import { API_BASE, IDP_BASE } from '../api.config';
 
 /**
- * Attaches the bearer token to API calls and transparently refreshes it once on a
- * 401. Auth endpoints (login / refresh / verify) are never retried to avoid loops.
+ * Attaches the bearer access token to calls to the resource API and the central IdP, and on a
+ * single 401 tries one silent SSO refresh (exchanging the shared cookie) before replaying the
+ * request. The /sso/session and /sso/logout endpoints are never refreshed, to avoid loops.
+ * Any unrecoverable 401 fails closed: clear state and redirect to the IdP sign-in.
  */
 export const authInterceptor: HttpInterceptorFn = (req, next) => {
   const auth = inject(AuthService);
-  const router = inject(Router);
   const base = inject(API_BASE);
+  const idp = inject(IDP_BASE);
 
-  const isApi = req.url.startsWith(base);
-  const isAuthRoute = req.url.includes('/auth/login')
-    || req.url.includes('/auth/refresh')
-    || req.url.includes('/auth/2fa/verify')
-    || req.url.includes('/auth/2fa/email/send');
+  const isApi = req.url.startsWith(base) || req.url.startsWith(idp);
+  const isSessionRoute = req.url.includes('/sso/session') || req.url.includes('/sso/logout');
 
   const token = auth.token();
   const authed = isApi && token
@@ -27,17 +25,16 @@ export const authInterceptor: HttpInterceptorFn = (req, next) => {
 
   return next(authed).pipe(
     catchError((err: HttpErrorResponse) => {
-      if (err.status !== 401 || !isApi || isAuthRoute || !auth.hasStoredSession()) {
+      if (err.status !== 401 || !isApi || isSessionRoute) {
         return throwError(() => err);
       }
-      // One refresh attempt, then replay the original request with the new token.
       return auth.refresh().pipe(
-        switchMap(tokens => next(req.clone({
-          setHeaders: { Authorization: `Bearer ${tokens.accessToken}` },
+        switchMap(session => next(req.clone({
+          setHeaders: { Authorization: `Bearer ${session.accessToken}` },
         }))),
         catchError(refreshErr => {
           auth.forceClear();
-          router.navigate(['/admin/login']);
+          auth.loginRedirect();
           return throwError(() => refreshErr);
         })
       );

--- a/ng-src/app/admin/pages/login.component.ts
+++ b/ng-src/app/admin/pages/login.component.ts
@@ -1,220 +1,34 @@
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
-import { CommonModule } from '@angular/common';
-import { FormsModule } from '@angular/forms';
-import { animate, style, transition, trigger } from '@angular/animations';
-import { Router } from '@angular/router';
+import { ChangeDetectionStrategy, Component, inject } from '@angular/core';
 import { AuthService } from '../services/auth.service';
-import { ThemeService } from '../../services/theme.service';
-import { ToastService } from '../services/toast.service';
-import { TwoFactorMethod } from '../admin.models';
 
+/**
+ * Sign-in is centralized at the identity provider (admin.keshavsingh.in). This route no longer
+ * renders a form — it immediately hands the browser to the IdP and returns to the console
+ * afterwards. Deep links that hit a guard are redirected the same way, with their own return URL.
+ */
 @Component({
   selector: 'app-admin-login',
   standalone: true,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [CommonModule, FormsModule],
   template: `
-    <div class="auth-page">
-      <div class="auth-aside">
-        <div class="auth-aside-inner">
-          <span class="admin-brand-mark lg"><i class="fas fa-shield-halved"></i></span>
-          <h1>Admin Console</h1>
-          <p>Manage content, media, users and security for your blog — protected by two-factor authentication.</p>
-          <ul class="auth-points">
-            <li><i class="fas fa-user-lock"></i> Authenticator-first sign in</li>
-            <li><i class="fas fa-envelope-circle-check"></i> Email code fallback</li>
-            <li><i class="fas fa-key"></i> One-time backup codes</li>
-          </ul>
-        </div>
-      </div>
-
-      <div class="auth-panel">
-        <button class="admin-topbar-btn ghost auth-theme" (click)="theme.toggle()" aria-label="Toggle theme">
-          <i class="fas" [class.fa-sun]="theme.theme() === 'dark'" [class.fa-moon]="theme.theme() === 'light'"></i>
-        </button>
-
-        <!-- Step 1: credentials -->
-        <form *ngIf="step() === 'password'" class="auth-card" (ngSubmit)="submitPassword()" @stepIn>
-          <h2>Welcome back</h2>
-          <p class="auth-sub">Sign in to continue to the console.</p>
-
-          <label class="field">
-            <span>Email or username</span>
-            <div class="field-input"><i class="fas fa-user"></i>
-              <input type="text" name="email" [(ngModel)]="email" autocomplete="username"
-                     placeholder="you@example.com" required autofocus>
-            </div>
-          </label>
-
-          <label class="field">
-            <span>Password</span>
-            <div class="field-input"><i class="fas fa-lock"></i>
-              <input [type]="showPw ? 'text' : 'password'" name="password" [(ngModel)]="password"
-                     autocomplete="current-password" placeholder="••••••••••••" required>
-              <button type="button" class="field-toggle" (click)="showPw = !showPw" tabindex="-1">
-                <i class="fas" [class.fa-eye]="!showPw" [class.fa-eye-slash]="showPw"></i>
-              </button>
-            </div>
-          </label>
-
-          <button class="btn-primary block" type="submit" [disabled]="busy()">
-            <i class="fas fa-arrow-right-to-bracket" *ngIf="!busy()"></i>
-            <i class="fas fa-spinner fa-spin" *ngIf="busy()"></i>
-            Continue
-          </button>
-        </form>
-
-        <!-- Step 2: two-factor -->
-        <form *ngIf="step() === 'twofactor'" class="auth-card" (ngSubmit)="submitCode()" @stepIn>
-          <button type="button" class="auth-back" (click)="backToPassword()">
-            <i class="fas fa-chevron-left"></i> Back
-          </button>
-          <h2>Two-factor verification</h2>
-          <p class="auth-sub">{{ methodHint() }}</p>
-
-          <div class="method-tabs">
-            <button type="button" [class.active]="method() === 'Totp'" (click)="setMethod('Totp')">
-              <i class="fas fa-mobile-screen"></i> Authenticator
-            </button>
-            <button type="button" [class.active]="method() === 'Email'" (click)="setMethod('Email')">
-              <i class="fas fa-envelope"></i> Email
-            </button>
-            <button type="button" *ngIf="smsAvailable()" [class.active]="method() === 'Sms'" (click)="setMethod('Sms')">
-              <i class="fas fa-comment-sms"></i> SMS
-            </button>
-            <button type="button" [class.active]="method() === 'BackupCode'" (click)="setMethod('BackupCode')">
-              <i class="fas fa-key"></i> Backup
-            </button>
-          </div>
-
-          <label class="field">
-            <span>{{ method() === 'BackupCode' ? 'Backup code' : '6-digit code' }}</span>
-            <div class="field-input"><i class="fas fa-hashtag"></i>
-              <input [type]="'text'" name="code" [(ngModel)]="code"
-                     [attr.inputmode]="method() === 'BackupCode' ? 'text' : 'numeric'"
-                     autocomplete="one-time-code" placeholder="{{ method() === 'BackupCode' ? 'xxxxx-xxxxx' : '000000' }}"
-                     class="code-input" required autofocus>
-            </div>
-          </label>
-
-          <button *ngIf="method() === 'Email'" type="button" class="link-btn" (click)="sendEmail()" [disabled]="busy()">
-            <i class="fas fa-paper-plane"></i> Send a code to my email
-          </button>
-          <button *ngIf="method() === 'Sms'" type="button" class="link-btn" (click)="sendSms()" [disabled]="busy()">
-            <i class="fas fa-paper-plane"></i> Text a code to my phone
-          </button>
-
-          <button class="btn-primary block" type="submit" [disabled]="busy()">
-            <i class="fas fa-shield-check" *ngIf="!busy()"></i>
-            <i class="fas fa-spinner fa-spin" *ngIf="busy()"></i>
-            Verify &amp; sign in
-          </button>
-        </form>
-      </div>
+    <div class="sso-redirect">
+      <i class="fas fa-shield-halved"></i>
+      <p>Redirecting to sign in…</p>
     </div>
   `,
-  animations: [
-    trigger('stepIn', [
-      transition(':enter', [
-        style({ opacity: 0, transform: 'translateY(14px)' }),
-        animate('380ms cubic-bezier(0.16,1,0.3,1)', style({ opacity: 1, transform: 'none' })),
-      ]),
-    ]),
-  ],
+  styles: [`
+    .sso-redirect {
+      min-height: 60vh; display: flex; flex-direction: column; gap: 0.75rem;
+      align-items: center; justify-content: center; color: var(--admin-muted, #8a8f98);
+    }
+    .sso-redirect i { font-size: 1.75rem; }
+  `],
 })
 export class LoginComponent {
   private auth = inject(AuthService);
-  private router = inject(Router);
-  private toast = inject(ToastService);
-  theme = inject(ThemeService);
 
-  email = '';
-  password = '';
-  code = '';
-  showPw = false;
-
-  step = signal<'password' | 'twofactor'>('password');
-  method = signal<TwoFactorMethod>('Totp');
-  smsAvailable = signal(false);
-  busy = signal(false);
-  private twoFactorToken = '';
-
-  methodHint(): string {
-    switch (this.method()) {
-      case 'Totp': return 'Enter the 6-digit code from your authenticator app.';
-      case 'Email': return 'We can email you a one-time code as a fallback.';
-      case 'Sms': return 'We can text a one-time code to your phone.';
-      case 'BackupCode': return 'Enter one of your saved one-time backup codes.';
-    }
-  }
-
-  setMethod(m: TwoFactorMethod): void {
-    this.method.set(m);
-    this.code = '';
-  }
-
-  submitPassword(): void {
-    if (!this.email || !this.password) return;
-    this.busy.set(true);
-    this.auth.login(this.email.trim(), this.password).subscribe({
-      next: res => {
-        this.busy.set(false);
-        if (res.twoFactorRequired && res.twoFactorToken) {
-          this.twoFactorToken = res.twoFactorToken;
-          this.smsAvailable.set(res.smsFallbackAvailable);
-          this.step.set('twofactor');
-        } else if (res.tokens) {
-          this.success();
-        }
-      },
-      error: err => {
-        this.busy.set(false);
-        this.toast.fromError(err, 'Invalid credentials.');
-      },
-    });
-  }
-
-  submitCode(): void {
-    if (!this.code) return;
-    this.busy.set(true);
-    this.auth.verifyTwoFactor(this.twoFactorToken, this.code.trim(), this.method()).subscribe({
-      next: () => this.success(),
-      error: err => {
-        this.busy.set(false);
-        // A genuinely expired 2FA session: send them back to re-enter the password.
-        if (err?.status === 401) {
-          this.step.set('password');
-          this.code = '';
-          this.toast.error('Your sign-in session expired — please sign in again.');
-        } else {
-          this.toast.fromError(err, 'Invalid or expired code.');
-        }
-      },
-    });
-  }
-
-  sendEmail(): void {
-    this.busy.set(true);
-    this.auth.sendEmailOtp(this.twoFactorToken).subscribe({
-      next: () => { this.busy.set(false); this.toast.success('If the account exists, a code has been emailed.'); },
-      error: () => { this.busy.set(false); this.toast.success('If the account exists, a code has been emailed.'); },
-    });
-  }
-
-  sendSms(): void {
-    this.busy.set(true);
-    const done = () => { this.busy.set(false); this.toast.success('If a phone is on file, a code has been sent.'); };
-    this.auth.sendSmsOtp(this.twoFactorToken).subscribe({ next: done, error: done });
-  }
-
-  backToPassword(): void {
-    this.step.set('password');
-    this.code = '';
-  }
-
-  private success(): void {
-    this.busy.set(false);
-    this.toast.success('Signed in.');
-    this.router.navigate(['/admin']);
+  constructor() {
+    // Return to the console root after a successful sign-in (hash route on GitHub Pages).
+    this.auth.loginRedirect(`${location.origin}/#/admin`);
   }
 }

--- a/ng-src/app/admin/services/auth.service.ts
+++ b/ng-src/app/admin/services/auth.service.ts
@@ -1,20 +1,25 @@
 import { Injectable, computed, inject, signal } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable, tap } from 'rxjs';
-import { API_BASE } from '../api.config';
-import {
-  AuthTokens, EnrollStartResponse, LoginResponse, Role,
-  TwoFactorMethod, UserProfile,
-} from '../admin.models';
+import { ADMIN_APP_URL, IDP_BASE } from '../api.config';
+import { EnrollStartResponse, Role, SsoSession, UserProfile } from '../admin.models';
 
-const REFRESH_KEY = 'admin.refresh';
-
+/**
+ * Auth client for the blog admin console. This app is an SSO CONSUMER: it does not authenticate
+ * users itself. Sessions come from the central identity provider (admin.keshavsingh.in) via the
+ * shared HttpOnly cookie — {@link refresh} silently exchanges that cookie for a short-lived access
+ * token (kept in memory only). Interactive sign-in happens by redirecting to the IdP.
+ *
+ * Account self-service (2FA enrolment, password change) is proxied to the IdP with the bearer
+ * token, so those pages continue to work against the single identity source.
+ */
 @Injectable({ providedIn: 'root' })
 export class AuthService {
   private http = inject(HttpClient);
-  private base = inject(API_BASE);
+  private idp = inject(IDP_BASE);
+  private adminApp = inject(ADMIN_APP_URL);
 
-  /** Access token is kept in memory only (not localStorage) to limit XSS exposure. */
+  /** Access token in memory only (not localStorage) to limit XSS exposure. */
   private accessToken = signal<string | null>(null);
   readonly user = signal<UserProfile | null>(null);
 
@@ -29,82 +34,63 @@ export class AuthService {
     return !!u && roles.some(r => u.roles.includes(r));
   }
 
-  // ---- Login flow ----
+  // ---- Session (silent SSO) ----
 
-  login(email: string, password: string): Observable<LoginResponse> {
-    return this.http.post<LoginResponse>(`${this.base}/auth/login`, { email, password }).pipe(
-      tap(res => { if (res.tokens) this.setSession(res.tokens); })
-    );
-  }
-
-  verifyTwoFactor(twoFactorToken: string, code: string, method: TwoFactorMethod): Observable<AuthTokens> {
+  /** Exchange the shared SSO cookie for a fresh access token. 401 => not signed in. */
+  refresh(): Observable<SsoSession> {
     return this.http
-      .post<AuthTokens>(`${this.base}/auth/2fa/verify`, { twoFactorToken, code, method })
-      .pipe(tap(tokens => this.setSession(tokens)));
+      .post<SsoSession>(`${this.idp}/sso/session`, {}, { withCredentials: true })
+      .pipe(tap(session => this.setSession(session)));
   }
 
-  sendEmailOtp(twoFactorToken: string): Observable<void> {
-    return this.http.post<void>(`${this.base}/auth/2fa/email/send`, { twoFactorToken });
-  }
-
-  sendSmsOtp(twoFactorToken: string): Observable<void> {
-    return this.http.post<void>(`${this.base}/auth/2fa/sms/send`, { twoFactorToken });
-  }
-
-  // ---- Session ----
-
-  private setSession(tokens: AuthTokens): void {
-    this.accessToken.set(tokens.accessToken);
-    this.user.set(tokens.user);
-    localStorage.setItem(REFRESH_KEY, tokens.refreshToken);
-  }
-
-  private clearSession(): void {
-    this.accessToken.set(null);
-    this.user.set(null);
-    localStorage.removeItem(REFRESH_KEY);
-  }
-
-  /** Restore a session on app start / after a 401 using the stored refresh token. */
-  refresh(): Observable<AuthTokens> {
-    const refreshToken = localStorage.getItem(REFRESH_KEY) ?? '';
-    return this.http
-      .post<AuthTokens>(`${this.base}/auth/refresh`, { refreshToken })
-      .pipe(tap(tokens => this.setSession(tokens)));
-  }
-
+  /** The refresh token is an HttpOnly cookie we cannot read, so always attempt a silent session. */
   hasStoredSession(): boolean {
-    return !!localStorage.getItem(REFRESH_KEY);
+    return true;
   }
 
   logout(): Observable<void> {
-    const refreshToken = localStorage.getItem(REFRESH_KEY);
-    const req = this.http.post<void>(`${this.base}/auth/logout`, { refreshToken });
-    return req.pipe(tap({ next: () => this.clearSession(), error: () => this.clearSession() }));
+    return this.http
+      .post<void>(`${this.idp}/sso/logout`, {}, { withCredentials: true })
+      .pipe(tap({ next: () => this.clearSession(), error: () => this.clearSession() }));
+  }
+
+  /** Send the browser to the central IdP to sign in, returning to {@link returnTo} afterwards. */
+  loginRedirect(returnTo: string = location.href): void {
+    location.href = `${this.adminApp}/login?return=${encodeURIComponent(returnTo)}`;
   }
 
   forceClear(): void {
     this.clearSession();
   }
 
-  // ---- Self-service 2FA enrollment ----
+  private setSession(session: SsoSession): void {
+    this.accessToken.set(session.accessToken);
+    this.user.set(session.user);
+  }
+
+  private clearSession(): void {
+    this.accessToken.set(null);
+    this.user.set(null);
+  }
+
+  // ---- Self-service against the central IdP (bearer; the interceptor attaches the token) ----
 
   enrollStart(): Observable<EnrollStartResponse> {
-    return this.http.post<EnrollStartResponse>(`${this.base}/auth/2fa/enroll/start`, {});
+    return this.http.post<EnrollStartResponse>(`${this.idp}/auth/2fa/enroll/start`, {});
   }
 
   enrollConfirm(code: string): Observable<{ backupCodes: string[] }> {
-    return this.http.post<{ backupCodes: string[] }>(`${this.base}/auth/2fa/enroll/confirm`, { code })
+    return this.http.post<{ backupCodes: string[] }>(`${this.idp}/auth/2fa/enroll/confirm`, { code })
       .pipe(tap(() => this.patchUser({ twoFactorEnabled: true })));
   }
 
   disableTwoFactor(password: string): Observable<void> {
-    return this.http.post<void>(`${this.base}/auth/2fa/disable`, { password })
+    return this.http.post<void>(`${this.idp}/auth/2fa/disable`, { password })
       .pipe(tap(() => this.patchUser({ twoFactorEnabled: false })));
   }
 
   changePassword(currentPassword: string, newPassword: string): Observable<void> {
-    return this.http.post<void>(`${this.base}/auth/change-password`, { currentPassword, newPassword })
+    return this.http.post<void>(`${this.idp}/auth/change-password`, { currentPassword, newPassword })
       .pipe(tap(() => this.patchUser({ mustChangePassword: false })));
   }
 

--- a/ng-src/index.html
+++ b/ng-src/index.html
@@ -19,6 +19,15 @@
     build, point it at your Render backend by uncommenting and editing the line below.
   -->
   <script>window.__ADMIN_API_BASE__ = 'https://content-blog-nms8.onrender.com/api';</script>
+  <!--
+    Central identity provider (admin.keshavsingh.in). The console gets its session from here via
+    the shared SSO cookie. __IDP_API_BASE__ must be a keshavsingh.in subdomain so the cookie is
+    sent; __ADMIN_APP_URL__ is the IdP SPA used for interactive sign-in redirects.
+  -->
+  <script>
+    window.__IDP_API_BASE__ = 'https://id.keshavsingh.in/api';
+    window.__ADMIN_APP_URL__ = 'https://admin.keshavsingh.in';
+  </script>
   <app-root></app-root>
 </body>
 </html>

--- a/server/Blog.Admin.Api/Program.cs
+++ b/server/Blog.Admin.Api/Program.cs
@@ -65,7 +65,8 @@ builder.Services.Configure<ForwardedHeadersOptions>(o =>
 
 builder.Services
     .AddControllers()
-    .AddKeshavAuthControllers() // discover the shared /api/auth controller from the package
+    // No local /api/auth controller: this app is a RESOURCE server. Authentication is centralized
+    // at the identity provider (admin.keshavsingh.in). We only VALIDATE its tokens below.
     .AddJsonOptions(options =>
         // Accept/emit enums as their string names (e.g. "Totp") to match the UI.
         options.JsonSerializerOptions.Converters.Add(
@@ -172,12 +173,12 @@ app.UseAuthentication();
 app.UseAuthorization();
 app.MapControllers();
 
-// ---- First-run admin seed ----
+// ---- Startup init ----
 using (var scope = app.Services.CreateScope())
 {
-    // Load/seed settings before anything that reads them.
+    // Load/seed settings before anything that reads them. Identity is centralized at the IdP
+    // (admin.keshavsingh.in), so this app no longer seeds or stores its own login users.
     await scope.ServiceProvider.GetRequiredService<SettingsService>().InitAsync();
-    await scope.ServiceProvider.GetRequiredService<AdminSeeder>().SeedAsync();
 }
 
 app.Run();

--- a/server/Blog.Admin.Api/appsettings.json
+++ b/server/Blog.Admin.Api/appsettings.json
@@ -15,9 +15,9 @@
     "Database": "blog_admin"
   },
   "Jwt": {
-    "//": "Signing key and secrets come from user-secrets / Key Vault, never this file.",
-    "Issuer": "blog-admin-api",
-    "Audience": "blog-admin-ui",
+    "//": "This API is a RESOURCE server only — it VALIDATES tokens issued by the central identity provider (admin.keshavsingh.in). Issuer/Audience/SigningKey must match the IdP. Signing key comes from user-secrets / Key Vault, never this file.",
+    "Issuer": "keshavsingh-idp",
+    "Audience": "keshavsingh-apps",
     "SigningKey": "",
     "AccessTokenMinutes": 15,
     "RefreshTokenDays": 7,


### PR DESCRIPTION
- backend: become a resource server only — validate the unified identity (issuer keshavsingh-idp / audience keshavsingh-apps, shared signing key); remove the local /api/auth login surface and the local admin seed.
- frontend admin console: get sessions from the IdP via the shared SSO cookie (silent /sso/session), redirect to the IdP for interactive sign-in, proxy 2FA/password self-service to the IdP. Access token in memory only; no local refresh token. IdP endpoints configurable via window.__IDP_API_BASE__ / window.__ADMIN_APP_URL__.